### PR TITLE
Fix double read when zipping files

### DIFF
--- a/lib/export_photos.go
+++ b/lib/export_photos.go
@@ -2,12 +2,11 @@ package lib
 
 import (
 	"bytes"
-
-	"github.com/pocketbase/pocketbase/tools/filesystem/blob"
+	"io"
 )
 
 type FileInfo struct {
-	Reader   *blob.Reader
+	Reader   io.ReadCloser
 	Filename string
 }
 

--- a/lib/util.go
+++ b/lib/util.go
@@ -64,12 +64,9 @@ func createZip(files []FileInfo, logger *log.Logger) (*bytes.Buffer, error) {
 			continue
 		}
 		// Use a preallocated buffer from our pool.
-		buf := bufPool.Get().([]byte)
-		_, err = io.CopyBuffer(zipFile, file.Reader, buf)
-		bufPool.Put(buf) // return the buffer
-
-		// Copy the file content to the zip
-		_, err = io.Copy(zipFile, file.Reader)
+		copyBuf := bufPool.Get().([]byte)
+		_, err = io.CopyBuffer(zipFile, file.Reader, copyBuf)
+		bufPool.Put(copyBuf) // return the buffer
 		if err != nil {
 			logger.Printf("Error copying content for %s: %v", file.Filename, err)
 		}

--- a/lib/util_test.go
+++ b/lib/util_test.go
@@ -1,0 +1,59 @@
+package lib
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"log"
+	"testing"
+)
+
+type eofCountingReader struct {
+	data     []byte
+	pos      int
+	eofReads int
+}
+
+func (r *eofCountingReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		r.eofReads++
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *eofCountingReader) Close() error { return nil }
+
+func TestCreateZipSingleRead(t *testing.T) {
+	content := []byte("hello world")
+	r := &eofCountingReader{data: content}
+	files := []FileInfo{{Reader: r, Filename: "test.txt"}}
+
+	buf, err := createZip(files, log.New(io.Discard, "", 0))
+	if err != nil {
+		t.Fatalf("createZip returned error: %v", err)
+	}
+	if r.eofReads != 1 {
+		t.Fatalf("expected 1 EOF read, got %d", r.eofReads)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("failed to open zip: %v", err)
+	}
+	if len(zr.File) != 1 {
+		t.Fatalf("expected 1 file in zip, got %d", len(zr.File))
+	}
+	f, err := zr.File[0].Open()
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Fatalf("content mismatch: got %q want %q", string(data), string(content))
+	}
+}


### PR DESCRIPTION
## Summary
- avoid double reading when zipping exported product photos
- use generic `io.ReadCloser` for file zipping to simplify tests
- cover zipping logic with unit test

## Testing
- `go test ./lib -run TestCreateZipSingleRead -count=1`
- `go test ./...` *(fails: no required module provides package github.com/kisinga/dukahub/views/pages)*


------
https://chatgpt.com/codex/tasks/task_e_6891de2ae3048330b8c3c1e3852c71e1